### PR TITLE
Fix: Enhance content addition on login and resolve list exhaustion

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -211,28 +211,6 @@ async def fetch_from_omdb(params: dict) -> dict:
 async def search_and_store_content(title: str, content_type: str) -> Optional[ContentItem]:
     """Search OMDB and store content item"""
     params = {"t": title, "type": content_type}
-    omdb_data = await fetch_from_omdb(params)
-    
-    content_item = ContentItem(
-        imdb_id=omdb_data.get("imdbID"),
-        title=omdb_data.get("Title"),
-        year=omdb_data.get("Year"),
-        content_type="movie" if omdb_data.get("Type") == "movie" else "series",
-        genre=omdb_data.get("Genre", ""),
-        rating=omdb_data.get("imdbRating"),
-        poster=omdb_data.get("Poster") if omdb_data.get("Poster") != "N/A" else None,
-        plot=omdb_data.get("Plot"),
-        director=omdb_data.get("Director"),
-        actors=omdb_data.get("Actors")
-    )
-    
-    # Store in database
-    await db.content.insert_one(content_item.dict())
-    return content_item
-
-async def search_and_store_content(title: str, content_type: str) -> Optional[ContentItem]:
-    """Search OMDB and store content item"""
-    params = {"t": title, "type": content_type}
     if content_type == "series":
         params["type"] = "series"
     omdb_data = await fetch_from_omdb(params)


### PR DESCRIPTION
- Modify `auto_add_content_on_login` to use larger global popular movie/TV show lists instead of small, local static lists.
- Implement random sampling from these larger lists to increase the chance of finding new content not yet in the database.
- Remove the initial, problematic `startswith` title deduplication check.
- Standardize deduplication keys using OMDB-returned title and year for better consistency.
- Update `auto_add_content_on_login` to use the `fetch_from_omdb` wrapper for more robust API calls and error handling.
- Remove one of two duplicate `search_and_store_content` function definitions.
- Improve logging within the content addition process.

This resolves the issue where no new content was being added on login due to the exhaustion of the previously used small, static content lists.